### PR TITLE
only pop "cache_position" if it exists

### DIFF
--- a/llava/model/language_model/llava_llama.py
+++ b/llava/model/language_model/llava_llama.py
@@ -152,7 +152,8 @@ class LlavaLlamaForCausalLM(LlamaForCausalLM, LlavaMetaForCausalLM):
             inputs_embeds=inputs_embeds,
             **kwargs,
         )
-        inputs.pop("cache_position")
+        if "cache_position" in inputs:
+            inputs.pop("cache_position")
         if images is not None:
             inputs["images"] = images
         if image_sizes is not None:


### PR DESCRIPTION
this was preventing inference in combination with VLMEvalKit